### PR TITLE
Support finding lockfile based on BUNDLE_GEMFILE

### DIFF
--- a/lib/bundle_cache/cache.rb
+++ b/lib/bundle_cache/cache.rb
@@ -12,9 +12,13 @@ module BundleCache
 
     file_name       = "#{ENV['BUNDLE_ARCHIVE']}-#{architecture}.tgz"
     file_path       = "#{processing_dir}/#{file_name}"
-    lock_file       = File.join(File.expand_path(ENV["TRAVIS_BUILD_DIR"].to_s), "Gemfile.lock")
     digest_filename = "#{file_name}.sha2"
     old_digest      = File.expand_path("#{processing_dir}/remote_#{digest_filename}")
+    lock_file       = if ENV["BUNDLE_GEMFILE"]
+                        File.expand_path("#{ENV['BUNDLE_GEMFILE']}.lock")
+                      else
+                        File.join(File.expand_path(ENV["TRAVIS_BUILD_DIR"].to_s), "Gemfile.lock")
+                      end
 
     puts "Checking for changes"
     bundle_digest = Digest::SHA2.file(lock_file).hexdigest


### PR DESCRIPTION
I have some libraries using the `gemfile` option in travis.yml to run against multiple different gemfiles. These projects ship without a top-level Gemfile.lock; instead, bundle will generate individual lockfiles for each entry in the `gemfile` array.

Using the option sets the `BUNDLE_GEMFILE` environment variable, so if that is set, you can simply append ".lock" to locate the lockfile, rather than assuming it will be in `./Gemfile.lock`.

(Originally @ https://github.com/data-axle/bundle_cache/pull/12)
